### PR TITLE
Deinit fix

### DIFF
--- a/adafruit_aw9523.py
+++ b/adafruit_aw9523.py
@@ -250,3 +250,8 @@ class DigitalInOut:
     def pull(self, val):  # pylint: disable=no-self-use
         if val is not None:
             raise NotImplementedError("Pull-up/pull-down resistors not supported.")
+
+    def deinit(self):
+        """ Deinitialize the Digital Pin """
+        self.switch_to_output()
+        del self._pin

--- a/adafruit_aw9523.py
+++ b/adafruit_aw9523.py
@@ -253,5 +253,5 @@ class DigitalInOut:
 
     def deinit(self):
         """ Deinitialize the Digital Pin """
+	# Don't actually destroy this object, just reset the pin to output, which is defaut.
         self.switch_to_output()
-        del self._pin


### PR DESCRIPTION
Adds a deinit method to the DigitalInOut object created by AW9523. Tested and seems to now allow AW9523 DigitalInOut objects to be used as a drop-in for digitalio.DigitalInOut objects. That said, not a python expert and this is my first public pull request, so likely needs a second set of eyes.